### PR TITLE
Issue 21413 browse img dialog on create image content not having splitter on left sidebar

### DIFF
--- a/scss/backend/dot-admin/components/_file-selector-tree.scss
+++ b/scss/backend/dot-admin/components/_file-selector-tree.scss
@@ -87,13 +87,6 @@
     text-align: center;
 }
 
-.file-selector-tree__main {
-    display: flex;
-    height: 84vh !important;
-    width: calc(100% - 200px) !important;
-    overflow: inherit;
-}
-
 .file-selector-tree__sidebar {
     padding: $basic-padding * 2 0 $basic-padding * 2 $basic-padding * 2;
 

--- a/scss/backend/dot-admin/portlets/_content-edit.scss
+++ b/scss/backend/dot-admin/portlets/_content-edit.scss
@@ -33,10 +33,16 @@ $sidebar-width: 300px;
 }
 
 .content-edit__main {
-  margin: $basic-padding * 2 $sidebar-width 0 0;
+  height: 100%;
+  margin: 0px $sidebar-width 0 0;
   position: relative;
+  padding-top: $basic-padding * 2;
   width: auto;
   z-index: 1;
+}
+
+#fm {
+  height: 100%;
 }
 
 .content-edit__form,

--- a/scss/dijit/layout/_tabContainer.scss
+++ b/scss/dijit/layout/_tabContainer.scss
@@ -184,8 +184,10 @@
     }
 
     &ContainerTop-container {
+      /* 42px is the height of the dijitTabListContainer */
+      height: calc(100% - 42px);
       border-top: none;
-      overflow: visible;
+      overflow: auto;
     }
 
     &ContainerBottom-container {


### PR DESCRIPTION
On a content having "image" field, clicking on Browse button opens "Select a file " popup showing project folder structure on left pane.

Client reported that there is no handle to resize the left pane and they have to rely on horizontal scrollbar which shows only when expanded folders are long enough for need of scrollbar. This is not user friendly for them or consistent with other screens.

All we need is existing functionality/handle which is available on Site > Browser to expand left pane to see the long folder names easily on Image field >browse menu.

![image](https://user-images.githubusercontent.com/37185433/146999571-89350e7b-029e-429d-9754-a4268845b16b.png)
